### PR TITLE
vars: updating the aws_ami description

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ EXAMPLE
 |------|-------------|:----:|:-----:|:-----:|
 | admin_ips | List of CIDR admin IPs | list | - | yes |
 | availability_zones | Availability zones to be used | list | `<list>` | no |
-| aws_ami | AMI that will be used for the instances instead of Mesosphere provided AMIs | string | `` | no |
+| aws_ami | AMI that will be used for the instances instead of the Mesosphere chosen default images. Custom AMIs must fulfill the Mesosphere DC/OS system-requirements: See https://docs.mesosphere.com/1.12/installing/production/system-requirements/ | string | `` | no |
 | aws_key_name | Specify the aws ssh key to use. We assume its already loaded in your SSH agent. Set ssh_public_key to none | string | `` | no |
 | bootstrap_associate_public_ip_address | [BOOTSTRAP] Associate a public ip address with there instances | string | `true` | no |
 | bootstrap_aws_ami | [BOOTSTRAP] AMI to be used | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ module "dcos-install" {
   public_agents_prereq-id = "${coalesce(var.public_agents_prereq-id, module.dcos-infrastructure.public_agents.prereq-id)}"
   num_public_agents       = "${coalesce(var.num_public_agents, var.num_public_agents)}"
   # DC/OS options
-  dcos_cluster_name = "${coalesce(var.dcos_cluster_name, local.cluster_name)}"
+  dcos_cluster_name                            = "${coalesce(var.dcos_cluster_name, local.cluster_name)}"
   custom_dcos_download_path                    = "${var.custom_dcos_download_path}"
   dcos_adminrouter_tls_1_0_enabled             = "${var.dcos_adminrouter_tls_1_0_enabled}"
   dcos_adminrouter_tls_1_1_enabled             = "${var.dcos_adminrouter_tls_1_1_enabled}"

--- a/variables.tf
+++ b/variables.tf
@@ -56,7 +56,7 @@ variable "availability_zones" {
 }
 
 variable "aws_ami" {
-  description = "AMI that will be used for the instances instead of Mesosphere provided AMIs"
+  description = "AMI that will be used for the instances instead of the Mesosphere chosen default images. Custom AMIs must fulfill the Mesosphere DC/OS system-requirements: See https://docs.mesosphere.com/1.12/installing/production/system-requirements/"
   default     = ""
 }
 


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-47942

This commit is to be more descriptive on the aws_ami variable to allow users more visibility into what AMI's are required and how they are built.
The link to the mesosphere documentation is in the description of the variable.